### PR TITLE
(상세화면) 글자 수, 링크/장소 구분, 흐르도록, (홈화면) 아래 하얀색 가로 바 제거 

### DIFF
--- a/app/src/main/java/org/inu/events/ui/adapter/BlockedAccountAdapter.kt
+++ b/app/src/main/java/org/inu/events/ui/adapter/BlockedAccountAdapter.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.inu.events.data.model.entity.User
 import org.inu.events.databinding.ItemBlockedAccountBinding
-import org.inu.events.dialog.TwoButtonDialog
+import org.inu.events.ui.util.dialog.TwoButtonDialog
 import org.inu.events.ui.mypage.shortcut.BlockedAccountViewModel
 
 class BlockedAccountAdapter(val viewModel: BlockedAccountViewModel) :

--- a/app/src/main/java/org/inu/events/ui/detail/CommentActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/detail/CommentActivity.kt
@@ -19,8 +19,8 @@ import org.inu.events.common.extension.observeNonNull
 import org.inu.events.common.extension.toast
 import org.inu.events.common.threading.execute
 import org.inu.events.databinding.ActivityCommentBinding
-import org.inu.events.dialog.AlarmDialog
-import org.inu.events.dialog.LoginDialog
+import org.inu.events.ui.util.dialog.AlarmDialog
+import org.inu.events.ui.util.dialog.LoginDialog
 import org.inu.events.lib.actionsheet.UniActionSheet
 import org.inu.events.objects.IntentMessage.EVENT_ID
 import org.inu.events.service.LoginService

--- a/app/src/main/java/org/inu/events/ui/detail/DetailActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/detail/DetailActivity.kt
@@ -53,9 +53,10 @@ class DetailActivity : AppCompatActivity(), LoginDialog.LoginDialog {
 
     private fun setTextView() {
         binding.apply {
-            textViewContact.isSelected = true
             textViewCategory.isSelected = true
             textViewTarget.isSelected = true
+            textViewContact.isSelected = true
+            textViewLocation.isSelected = true
         }
     }
 

--- a/app/src/main/java/org/inu/events/ui/detail/DetailActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/detail/DetailActivity.kt
@@ -11,8 +11,8 @@ import org.inu.events.R
 import org.inu.events.ui.register.RegisterEventsActivity
 import org.inu.events.common.extension.*
 import org.inu.events.databinding.ActivityDetailBinding
-import org.inu.events.dialog.AlarmDialog
-import org.inu.events.dialog.LoginDialog
+import org.inu.events.ui.util.dialog.AlarmDialog
+import org.inu.events.ui.util.dialog.LoginDialog
 import org.inu.events.lib.actionsheet.UniActionSheet
 import org.inu.events.objects.IntentMessage.EVENT_ID
 import org.inu.events.objects.IntentMessage.MY_WROTE
@@ -178,7 +178,8 @@ class DetailActivity : AppCompatActivity(), LoginDialog.LoginDialog {
                     .addText("글 메뉴")
                     .addAction("신고하기") {
                         if (loginService.isLoggedIn){ }
-                        else{LoginDialog().show(this, { onOk() }, { toast("로그인을 하셔야 신고하실 수 있습니다!") })}
+                        else{
+                            LoginDialog().show(this, { onOk() }, { toast("로그인을 하셔야 신고하실 수 있습니다!") })}
                     }
                     .show()
             }

--- a/app/src/main/java/org/inu/events/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/detail/DetailViewModel.kt
@@ -3,6 +3,7 @@ package org.inu.events.ui.detail
 import android.content.Context
 import android.util.Log
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import org.inu.events.R
 import org.inu.events.common.extension.toast
@@ -17,14 +18,10 @@ import org.inu.events.data.repository.BlockRepository
 import org.inu.events.data.repository.EventRepository
 import org.inu.events.data.repository.LikeRepository
 import org.inu.events.data.repository.NotificationRepository
-import org.inu.events.ui.util.dialog.LoginDialog
 import org.inu.events.service.LoginService
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.text.SimpleDateFormat
 import java.time.*
-import java.time.format.DateTimeFormatter
-import java.util.*
 
 class DetailViewModel : ViewModel(),KoinComponent {
     private val eventRepository: EventRepository by inject()
@@ -38,6 +35,10 @@ class DetailViewModel : ViewModel(),KoinComponent {
     private val _currentEvent = MutableLiveData<Event>()
     val currentEvent: MutableLiveData<Event>
         get() = _currentEvent
+
+    var locationLabel = Transformations.map(currentEvent) {
+        if (it.location?.contains("http") == true) "신청링크" else "신청장소"
+    }
 
     var imageUrl = MutableLiveData("")
     var startDate = MutableLiveData("")

--- a/app/src/main/java/org/inu/events/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/detail/DetailViewModel.kt
@@ -17,7 +17,7 @@ import org.inu.events.data.repository.BlockRepository
 import org.inu.events.data.repository.EventRepository
 import org.inu.events.data.repository.LikeRepository
 import org.inu.events.data.repository.NotificationRepository
-import org.inu.events.dialog.LoginDialog
+import org.inu.events.ui.util.dialog.LoginDialog
 import org.inu.events.service.LoginService
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject

--- a/app/src/main/java/org/inu/events/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/home/HomeViewModel.kt
@@ -16,7 +16,7 @@ import org.inu.events.data.model.dto.LikeParam
 import org.inu.events.data.model.entity.Event
 import org.inu.events.data.repository.EventRepository
 import org.inu.events.data.repository.LikeRepository
-import org.inu.events.dialog.LoginDialog
+import org.inu.events.ui.util.dialog.LoginDialog
 import org.inu.events.service.LoginService
 import org.inu.events.ui.login.LoginActivity
 import org.inu.events.ui.mypage.MyPageActivity

--- a/app/src/main/java/org/inu/events/ui/home/MainActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/home/MainActivity.kt
@@ -16,7 +16,7 @@ import org.inu.events.common.extension.observe
 import org.inu.events.common.extension.observeNonNull
 import org.inu.events.common.extension.toast
 import org.inu.events.databinding.ActivityMainBinding
-import org.inu.events.dialog.LoginDialog
+import org.inu.events.ui.util.dialog.LoginDialog
 import org.inu.events.service.LoginService
 import org.koin.android.ext.android.inject
 

--- a/app/src/main/java/org/inu/events/ui/mypage/store/LikeViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/mypage/store/LikeViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.inu.events.ui.detail.DetailActivity
-import org.inu.events.dialog.TwoButtonDialog
+import org.inu.events.ui.util.dialog.TwoButtonDialog
 import org.inu.events.data.model.dto.LikeParam
 import org.inu.events.data.model.entity.Event
 import org.inu.events.data.repository.LikeRepository

--- a/app/src/main/java/org/inu/events/ui/mypage/store/NotificationViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/mypage/store/NotificationViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.inu.events.ui.detail.DetailActivity
-import org.inu.events.dialog.TwoButtonDialog
+import org.inu.events.ui.util.dialog.TwoButtonDialog
 import org.inu.events.data.model.dto.NotificationParams
 import org.inu.events.data.model.entity.Event
 import org.inu.events.data.repository.NotificationRepository

--- a/app/src/main/java/org/inu/events/ui/util/dialog/AlarmDialog.kt
+++ b/app/src/main/java/org/inu/events/ui/util/dialog/AlarmDialog.kt
@@ -1,4 +1,4 @@
-package org.inu.events.dialog
+package org.inu.events.ui.util.dialog
 
 import android.app.AlertDialog
 import android.content.Context

--- a/app/src/main/java/org/inu/events/ui/util/dialog/BottomSheetDialog.kt
+++ b/app/src/main/java/org/inu/events/ui/util/dialog/BottomSheetDialog.kt
@@ -1,4 +1,4 @@
-package org.inu.events.dialog
+package org.inu.events.ui.util.dialog
 
 import android.content.Context
 import android.graphics.Color

--- a/app/src/main/java/org/inu/events/ui/util/dialog/BottomSheetDialogOneButton.kt
+++ b/app/src/main/java/org/inu/events/ui/util/dialog/BottomSheetDialogOneButton.kt
@@ -1,4 +1,4 @@
-package org.inu.events.dialog
+package org.inu.events.ui.util.dialog
 
 import android.content.Context
 import android.graphics.Color

--- a/app/src/main/java/org/inu/events/ui/util/dialog/LoginDialog.kt
+++ b/app/src/main/java/org/inu/events/ui/util/dialog/LoginDialog.kt
@@ -1,4 +1,4 @@
-package org.inu.events.dialog
+package org.inu.events.ui.util.dialog
 
 import android.content.Context
 import android.graphics.Color

--- a/app/src/main/java/org/inu/events/ui/util/dialog/TwoButtonDialog.kt
+++ b/app/src/main/java/org/inu/events/ui/util/dialog/TwoButtonDialog.kt
@@ -1,4 +1,4 @@
-package org.inu.events.dialog
+package org.inu.events.ui.util.dialog
 
 import android.content.Context
 import android.graphics.Color

--- a/app/src/main/java/org/inu/events/ui/util/toolbar/UniLetterToolbar.kt
+++ b/app/src/main/java/org/inu/events/ui/util/toolbar/UniLetterToolbar.kt
@@ -8,7 +8,7 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import org.inu.events.R
-import org.inu.events.dialog.AlarmDialog
+import org.inu.events.ui.util.dialog.AlarmDialog
 
 class UniLetterToolbar(context: Context, attrs: AttributeSet) : Toolbar(context, attrs) {
     private var title: String = ""

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -4,8 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <import type="androidx.core.content.ContextCompat" />
-        <import type="android.view.View"/>
+
+        <import type="android.view.View" />
 
         <variable
             name="detailViewModel"
@@ -24,7 +26,7 @@
             layout="@layout/toolbar_sample_read"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:viewModel="@{detailViewModel}"/>
+            app:viewModel="@{detailViewModel}" />
 
         <ScrollView
             android:layout_width="match_parent"
@@ -56,8 +58,8 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="8dp"
                         android:layout_marginTop="24dp"
-                        android:textSize="13sp"
                         android:text="@{detailViewModel.currentEvent.nickname}"
+                        android:textSize="13sp"
                         app:layout_constraintStart_toEndOf="@+id/circleImageView"
                         app:layout_constraintTop_toTopOf="parent"
                         tools:text="닉네임입니다." />
@@ -78,8 +80,8 @@
                         android:layout_width="16dp"
                         android:layout_height="16dp"
                         android:layout_marginTop="4dp"
-                        android:src="@drawable/ic_menu"
                         android:onClick="@{()->detailViewModel.onClickUserMenu()}"
+                        android:src="@drawable/ic_menu"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="@+id/textView" />
 
@@ -90,8 +92,8 @@
                     imageFromUrl="@{detailViewModel.imageUrl}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
                     android:layout_marginHorizontal="@dimen/detail_horizontal_margin"
+                    android:layout_marginTop="16dp"
                     android:adjustViewBounds="true"
                     android:paddingVertical="24dp"
                     android:scaleType="fitCenter"
@@ -106,48 +108,52 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp">
-                <LinearLayout
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/detail_horizontal_margin"
-                    android:layout_marginEnd="4dp"
-                    app:layout_constraintEnd_toStartOf="@id/boardDateLayout"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent">
 
-                    <TextView
-                        android:id="@+id/detailTitle"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/detail_horizontal_margin"
                         android:layout_marginEnd="4dp"
-                        android:text="@{detailViewModel.currentEvent.title}"
-                        tools:text="앱센터 13기 신입멤버 모집한드아아아아아아앙아아아아아아아아아악ㅋㅋㅋ아싸됐당"
-                        android:gravity="center_vertical"
-                        android:textColor="@color/black"
-                        android:textSize="18sp"
-                        android:textIsSelectable="true"/>
-                </LinearLayout>
-                <LinearLayout
-                    android:id="@+id/boardDateLayout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="20dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent">
-                <TextView
-                    android:id="@+id/board_date"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@{detailViewModel.boardDateText}"
-                    android:paddingHorizontal="10dp"
-                    android:paddingVertical="4dp"
-                    android:textColor="@color/white"
-                    android:textSize="13sp"
-                    android:background="@drawable/drawable_home_board_date_ongoing_background"
-                    android:backgroundTint="@{detailViewModel.deadLine ? @color/black8 : @color/primary}"
-                    tools:text="마감" />
-                </LinearLayout>
+                        app:layout_constraintEnd_toStartOf="@id/boardDateLayout"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            android:id="@+id/detailTitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:layout_marginEnd="4dp"
+                            android:gravity="center_vertical"
+                            android:text="@{detailViewModel.currentEvent.title}"
+                            android:textColor="@color/black"
+                            android:textIsSelectable="true"
+                            android:textSize="18sp"
+                            tools:text="앱센터 13기 신입멤버 모집한드아아아아아아앙아아아아아아아아아악ㅋㅋㅋ아싸됐당" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/boardDateLayout"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="20dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            android:id="@+id/board_date"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:background="@drawable/drawable_home_board_date_ongoing_background"
+                            android:backgroundTint="@{detailViewModel.deadLine ? @color/black8 : @color/primary}"
+                            android:paddingHorizontal="10dp"
+                            android:paddingVertical="4dp"
+                            android:text="@{detailViewModel.boardDateText}"
+                            android:textColor="@color/white"
+                            android:textSize="13sp"
+                            tools:text="마감" />
+                    </LinearLayout>
                 </androidx.constraintlayout.widget.ConstraintLayout>
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -165,14 +171,14 @@
                         android:id="@+id/textView_category"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
-                        tools:text="category | host"
-                        android:text="@{detailViewModel.hostNull ? detailViewModel.currentEvent.category : @string/group(detailViewModel.currentEvent.category,detailViewModel.currentEvent.host)}"
-                        android:textColor="@color/black1"
-                        android:textSize="15sp"
-                        android:textIsSelectable="true"
                         android:ellipsize="marquee"
                         android:marqueeRepeatLimit="marquee_forever"
-                        android:singleLine="true" />
+                        android:singleLine="true"
+                        android:text="@{detailViewModel.hostNull ? detailViewModel.currentEvent.category : @string/group(detailViewModel.currentEvent.category,detailViewModel.currentEvent.host)}"
+                        android:textColor="@color/black1"
+                        android:textIsSelectable="true"
+                        android:textSize="15sp"
+                        tools:text="category | host" />
                 </LinearLayout>
 
                 <LinearLayout
@@ -192,10 +198,10 @@
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
                         android:text="@{@string/event_period(detailViewModel.startDate, detailViewModel.startTime)}"
-                        tools:text="2021.03.22 - 6:00PM"
-                        android:textIsSelectable="true"
                         android:textColor="@color/black1"
-                        android:textSize="15sp" />
+                        android:textIsSelectable="true"
+                        android:textSize="15sp"
+                        tools:text="2021.03.22 - 6:00PM" />
                 </LinearLayout>
 
                 <LinearLayout
@@ -215,18 +221,18 @@
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
                         android:text="@{@string/event_period(detailViewModel.endDate, detailViewModel.endTime)}"
-                        tools:text="2021.03.22 - 8:00PM"
-                        android:textIsSelectable="true"
                         android:textColor="@color/black1"
-                        android:textSize="15sp" />
+                        android:textIsSelectable="true"
+                        android:textSize="15sp"
+                        tools:text="2021.03.22 - 8:00PM" />
                 </LinearLayout>
 
                 <LinearLayout
+                    layoutMarginBottom="@{detailViewModel.locationNull &amp;&amp; detailViewModel.contactNull ? @dimen/detail_bottom_margin : @dimen/detail_bottom_margin_null}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="@dimen/detail_horizontal_margin"
                     android:layout_marginTop="16dp"
-                    layoutMarginBottom="@{detailViewModel.locationNull &amp;&amp; detailViewModel.contactNull ? @dimen/detail_bottom_margin : @dimen/detail_bottom_margin_null}"
                     android:orientation="horizontal">
 
                     <TextView
@@ -239,24 +245,24 @@
                         android:id="@+id/textView_target"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
-                        android:text="@{detailViewModel.currentEvent.target}"
-                        tools:text="1년이상 활동 가능한 사람"
-                        android:textIsSelectable="true"
-                        android:textColor="@color/black1"
-                        android:textSize="15sp"
                         android:ellipsize="marquee"
                         android:marqueeRepeatLimit="marquee_forever"
-                        android:singleLine="true"/>
+                        android:singleLine="true"
+                        android:text="@{detailViewModel.currentEvent.target}"
+                        android:textColor="@color/black1"
+                        android:textIsSelectable="true"
+                        android:textSize="15sp"
+                        tools:text="1년이상 활동 가능한 사람" />
                 </LinearLayout>
 
                 <LinearLayout
+                    layoutMarginBottom="@{detailViewModel.locationNull ? @dimen/detail_bottom_margin : @dimen/detail_bottom_margin_null}"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="@dimen/detail_horizontal_margin"
                     android:layout_marginTop="16dp"
-                    layoutMarginBottom="@{detailViewModel.locationNull ? @dimen/detail_bottom_margin : @dimen/detail_bottom_margin_null}"
-                    android:visibility="@{detailViewModel.contactNull ? View.GONE : View.VISIBLE}"
-                android:orientation="horizontal">
+                    android:orientation="horizontal"
+                    android:visibility="@{detailViewModel.contactNull ? View.GONE : View.VISIBLE}">
 
                     <TextView
                         android:layout_width="80dp"
@@ -268,14 +274,14 @@
                         android:id="@+id/textView_contact"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
-                        android:text="@{detailViewModel.currentEvent.contact}"
-                        tools:text="카톡"
-                        android:textColor="@color/black1"
-                        android:textSize="15sp"
-                        android:textIsSelectable="true"
                         android:ellipsize="marquee"
                         android:marqueeRepeatLimit="marquee_forever"
-                        android:singleLine="true" />
+                        android:singleLine="true"
+                        android:text="@{detailViewModel.currentEvent.contact}"
+                        android:textColor="@color/black1"
+                        android:textIsSelectable="true"
+                        android:textSize="15sp"
+                        tools:text="카톡" />
                 </LinearLayout>
 
                 <LinearLayout
@@ -294,16 +300,18 @@
                         android:textSize="15sp" />
 
                     <TextView
+                        android:id="@+id/textView_location"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
-                        android:text="@{detailViewModel.currentEvent.location}"
                         android:autoLink="web"
+                        android:ellipsize="marquee"
+                        android:marqueeRepeatLimit="marquee_forever"
+                        android:singleLine="true"
+                        android:text="@{detailViewModel.currentEvent.location}"
                         android:textColor="@color/black1"
-                        android:textSize="15sp"
-                        tools:text="https://github.com/inu-appcenter"
                         android:textIsSelectable="true"
-                        android:maxLines="1"
-                        android:ellipsize="end"/>
+                        android:textSize="15sp"
+                        tools:text="https://gisssssssssssssssssthub.com/inu-appcenter" />
                 </LinearLayout>
 
                 <View
@@ -326,12 +334,11 @@
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="@dimen/detail_horizontal_margin"
                     android:layout_marginTop="16dp"
-                    tools:text="@string/detail_content"
-                    android:textIsSelectable="true"
                     android:text="@{detailViewModel.currentEvent.body}"
                     android:textColor="@color/black1"
+                    android:textIsSelectable="true"
                     android:textSize="15sp"
-                    />
+                    tools:text="@string/detail_content" />
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -364,12 +371,12 @@
                         android:id="@+id/commentTextView"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:onClick="@{()->detailViewModel.onClickComment()}"
                         android:text="@{@string/event_save_comments(detailViewModel.like,detailViewModel.currentEvent.comments)}"
                         android:textSize="15sp"
-                        android:onClick="@{()->detailViewModel.onClickComment()}"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
-                        tools:text = "저장 7 • 댓글 17개"/>
+                        tools:text="저장 7 • 댓글 17개" />
 
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
@@ -381,14 +388,14 @@
             android:id="@+id/NotificationButton"
             android:layout_width="match_parent"
             android:layout_height="52dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="16dp"
             android:background="@{ContextCompat.getDrawable(context,detailViewModel.notificationBackground)}"
+            android:onClick="@{()->detailViewModel.onClickNotification()}"
             android:paddingVertical="15dp"
             android:text="@{detailViewModel.notificationText}"
-            android:onClick="@{()->detailViewModel.onClickNotification()}"
             android:textColor="@{ContextCompat.getColor(context,detailViewModel.notificationColor)}"
             android:textSize="15sp"
-            tools:ignore="HardcodedText,TextContrastCheck"
-            android:layout_marginBottom="16dp"
-            android:layout_marginHorizontal="20dp"/>
+            tools:ignore="HardcodedText,TextContrastCheck" />
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -294,10 +294,12 @@
                     android:visibility="@{detailViewModel.locationNull ? View.GONE : View.VISIBLE}">
 
                     <TextView
+                        android:id="@+id/textView_location_label"
                         android:layout_width="80dp"
                         android:layout_height="wrap_content"
-                        android:text="신청링크"
-                        android:textSize="15sp" />
+                        android:textSize="15sp"
+                        android:text="@{detailViewModel.locationLabel}"
+                        tools:text="신청링크" />
 
                     <TextView
                         android:id="@+id/textView_location"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,6 +41,8 @@
             android:id="@+id/swipe_layout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:layout_marginHorizontal="14dp"
+            android:layout_marginTop="14dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -51,8 +53,6 @@
                 android:id="@+id/home_recyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_margin="14dp"
-                android:paddingBottom="48dp"
                 app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -64,7 +64,7 @@
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <ImageView
-            android:id="@+id/imageView2"
+            android:id="@+id/imageView_blur"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@drawable/ic_drawable_blur"

--- a/app/src/main/res/layout/activity_register_events.xml
+++ b/app/src/main/res/layout/activity_register_events.xml
@@ -726,7 +726,7 @@
                 android:hint="@string/hintText_body"
                 android:importantForAutofill="no"
                 android:inputType="textMultiLine"
-                android:maxLength="800"
+                android:maxLength="8000"
                 android:padding="16dp"
                 android:text="@={registerViewModel.body}"
                 android:textSize="16sp"


### PR DESCRIPTION
## 🚀 #14  #17 

## 👨‍🔧 개요
- 사소한 UI 처리들을 해결했습니다~

## 📝 작업 내용
- 읽어보기 화면 신청링크/장소 흐르드록
- 신청링크/장소 값에 따라 구분되도록 변경
- 상세레터 글자 수 변경
- 홈화면 드래그 중에 아래에 하얀 바가 나오는 현상 해결

## 📱 수정된 동작화면

https://user-images.githubusercontent.com/80373033/210323653-56d54baf-32bd-4e20-9b98-31e5620797b3.mp4

## 📢 특이 사항
허허~