### PR TITLE
fix: #23 - 홈 화면 북마크 클릭 이벤트가 현재 북마크 상태와 다르게 동작하는 버그 해결

### DIFF
--- a/app/src/main/java/org/inu/events/ui/adapter/HomeAdapter.kt
+++ b/app/src/main/java/org/inu/events/ui/adapter/HomeAdapter.kt
@@ -7,11 +7,11 @@ import androidx.core.content.ContextCompat
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import org.inu.events.ui.detail.DetailActivity
 import org.inu.events.R
 import org.inu.events.common.util.Period
 import org.inu.events.data.model.entity.Event
 import org.inu.events.databinding.HomeRecyclerviewItemBinding
+import org.inu.events.ui.detail.DetailActivity
 import org.inu.events.ui.home.HomeViewModel
 
 class HomeAdapter(val viewModel: HomeViewModel) :
@@ -65,16 +65,14 @@ class HomeAdapter(val viewModel: HomeViewModel) :
         private fun onClickLike() {
             binding.likeImageView.setOnClickListener {
                 binding.item?.let { event ->
-                    if (viewModel.onLikePost()) event.likedByMe = !(event.likedByMe ?: false)
-                    else viewModel.onLogIn()
-
-                    adapter.notifyItemChanged(bindingAdapterPosition)
+                    if (viewModel.onLikePost(event)) {
+                        viewModel.refresh()
+                    } else viewModel.onLogIn()
                 }
             }
         }
 
         fun bind(homeData: Event) {
-            viewModel.eventIndex = homeData.id
             binding.item = homeData
             binding.viewModel = viewModel
             binding.boardDate.text = period.whenDay(homeData.endAt)

--- a/app/src/main/java/org/inu/events/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/home/HomeViewModel.kt
@@ -32,8 +32,6 @@ class HomeViewModel : ViewModel(), KoinComponent {
     val homeDataList = _homeDataList.asStateFlow()
     private var categoryId = 0
     private var eventStatus = false
-    var eventIndex: Int = 0
-    private var like = false
 
     val postClickEvent = SingleLiveEvent<Any>()
     val likeClickEvent = SingleLiveEvent<Any>()
@@ -74,10 +72,10 @@ class HomeViewModel : ViewModel(), KoinComponent {
         likeClickEvent.call()
     }
 
-    fun onLikePost(): Boolean {
-        when {
-            like -> deleteLike(eventIndex)
-            else -> postLike(eventIndex)
+    fun onLikePost(event: Event): Boolean {
+        when (event.likedByMe) {
+            true -> deleteLike(event.id)
+            else -> postLike(event.id)
         }
         return loginService.isLoggedIn
     }


### PR DESCRIPTION
issue #23 

## 개요
홈 화면 북마크 클릭 이벤트가 오작동(원하는 예상 동작과 일치 X)

## 분석
HomeViewModel 에서 onLikePost() 가 eventIndex 및 like 상태를 잘못 인지하고 있었다.

## 해결
onLikePost 함수에게 Adapter 에서 클릭하는 행사(event) 를 던져준다.


### 추가  
클릭 후 북마크 상태를 바로 바꾸도록 구현되어 있었음.
하지만 그로 인해, 상세화면 갔다가 다시 나오면 refresh 되어서 실제 북마크 상태와 다른 경우가 발생

북마크 상태만 바로 바꾸기 보단 서버 데이터를 기준으로 해당 이벤트의 View 를 바꾸는 게 옳다 생각(데이터의 일관성) 해서 수정