### PR TITLE
Issue#21 검색 아이템 클릭 이벤트 및 북마크 처리

### DIFF
--- a/app/src/main/java/org/inu/events/ui/adapter/LikeAdapter.kt
+++ b/app/src/main/java/org/inu/events/ui/adapter/LikeAdapter.kt
@@ -1,4 +1,4 @@
-package org.inu.events.ui.adapter.like
+package org.inu.events.ui.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/app/src/main/java/org/inu/events/ui/adapter/SearchPagingAdapter.kt
+++ b/app/src/main/java/org/inu/events/ui/adapter/SearchPagingAdapter.kt
@@ -10,7 +10,7 @@ import org.inu.events.databinding.ItemSearchEventBinding
 
 class SearchPagingAdapter(
     val onClickEvent: (event: Event) -> Unit,
-    val onCLickLikeIcon: (event: Event) -> Boolean
+    val onCLickLikeIcon: (event: Event) -> Unit
 ) :
     PagingDataAdapter<Event, SearchPagingAdapter.ViewHolder>(SearchDiffUtil) {
 
@@ -26,8 +26,8 @@ class SearchPagingAdapter(
 
     class ViewHolder private constructor(
         val binding: ItemSearchEventBinding,
-        val _onClickEvent: (event: Event) -> Unit,
-        val _onCLickLikeIcon: (event: Event) -> Boolean
+        private val _onClickEvent: (event: Event) -> Unit,
+        private val _onCLickLikeIcon: (event: Event) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
 
 
@@ -57,7 +57,7 @@ class SearchPagingAdapter(
             fun from(
                 parent: ViewGroup,
                 onClickEvent: (event: Event) -> Unit,
-                onCLickLikeIcon: (event: Event) -> Boolean
+                onCLickLikeIcon: (event: Event) -> Unit
             ): ViewHolder {
                 val layoutInflater = LayoutInflater.from(parent.context)
                 val binding = ItemSearchEventBinding.inflate(layoutInflater, parent, false)

--- a/app/src/main/java/org/inu/events/ui/adapter/SearchPagingAdapter.kt
+++ b/app/src/main/java/org/inu/events/ui/adapter/SearchPagingAdapter.kt
@@ -1,4 +1,4 @@
-package org.inu.events.ui.adapter.like
+package org.inu.events.ui.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import org.inu.events.data.model.entity.Event
 import org.inu.events.databinding.ItemLikeEventBinding
 
-class LikePagingAdapter : PagingDataAdapter<Event, LikePagingAdapter.ViewHolder>(LikeDiffUtil) {
+class SearchPagingAdapter : PagingDataAdapter<Event, SearchPagingAdapter.ViewHolder>(LikeDiffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ViewHolder.from(parent)
 

--- a/app/src/main/java/org/inu/events/ui/adapter/SearchPagingAdapter.kt
+++ b/app/src/main/java/org/inu/events/ui/adapter/SearchPagingAdapter.kt
@@ -6,11 +6,17 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import org.inu.events.data.model.entity.Event
-import org.inu.events.databinding.ItemLikeEventBinding
+import org.inu.events.databinding.ItemSearchEventBinding
 
-class SearchPagingAdapter : PagingDataAdapter<Event, SearchPagingAdapter.ViewHolder>(LikeDiffUtil) {
+class SearchPagingAdapter(
+    val onClickEvent: (event: Event) -> Unit,
+    val onCLickLikeIcon: (event: Event) -> Boolean
+) :
+    PagingDataAdapter<Event, SearchPagingAdapter.ViewHolder>(SearchDiffUtil) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ViewHolder.from(parent)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ViewHolder.from(
+        parent, onClickEvent, onCLickLikeIcon
+    )
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         getItem(position)?.let { event ->
@@ -19,8 +25,28 @@ class SearchPagingAdapter : PagingDataAdapter<Event, SearchPagingAdapter.ViewHol
     }
 
     class ViewHolder private constructor(
-        val binding: ItemLikeEventBinding
+        val binding: ItemSearchEventBinding,
+        val _onClickEvent: (event: Event) -> Unit,
+        val _onCLickLikeIcon: (event: Event) -> Boolean
     ) : RecyclerView.ViewHolder(binding.root) {
+
+
+        init {
+            onClickEvent()
+            onClickLikeIcon()
+        }
+
+        private fun onClickEvent() {
+            itemView.setOnClickListener {
+                binding.item?.let(_onClickEvent)
+            }
+        }
+
+        private fun onClickLikeIcon() {
+            binding.bookmarkIcon.setOnClickListener {
+                binding.item?.let(_onCLickLikeIcon)
+            }
+        }
 
         fun bind(item: Event) {
             binding.item = item
@@ -28,16 +54,20 @@ class SearchPagingAdapter : PagingDataAdapter<Event, SearchPagingAdapter.ViewHol
         }
 
         companion object {
-            fun from(parent: ViewGroup): ViewHolder {
+            fun from(
+                parent: ViewGroup,
+                onClickEvent: (event: Event) -> Unit,
+                onCLickLikeIcon: (event: Event) -> Boolean
+            ): ViewHolder {
                 val layoutInflater = LayoutInflater.from(parent.context)
-                val binding = ItemLikeEventBinding.inflate(layoutInflater, parent, false)
+                val binding = ItemSearchEventBinding.inflate(layoutInflater, parent, false)
 
-                return ViewHolder(binding)
+                return ViewHolder(binding, onClickEvent, onCLickLikeIcon)
             }
         }
     }
 
-    companion object LikeDiffUtil : DiffUtil.ItemCallback<Event>() {
+    companion object SearchDiffUtil : DiffUtil.ItemCallback<Event>() {
         override fun areItemsTheSame(oldItem: Event, newItem: Event) = oldItem.id == newItem.id
 
         override fun areContentsTheSame(oldItem: Event, newItem: Event) = oldItem == newItem

--- a/app/src/main/java/org/inu/events/ui/binding/AdapterBinding.kt
+++ b/app/src/main/java/org/inu/events/ui/binding/AdapterBinding.kt
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.RecyclerView
 import org.inu.events.data.model.entity.Event
 import org.inu.events.data.model.entity.User
 import org.inu.events.ui.adapter.*
-import org.inu.events.ui.adapter.like.LikeAdapter
+import org.inu.events.ui.adapter.LikeAdapter
 
 @BindingAdapter("app:likes")
 fun setLikes(recyclerView: RecyclerView, list: List<Event>?) {

--- a/app/src/main/java/org/inu/events/ui/home/SearchActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/home/SearchActivity.kt
@@ -9,13 +9,13 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.inu.events.databinding.ActivitySearchBinding
-import org.inu.events.ui.adapter.like.LikePagingAdapter
+import org.inu.events.ui.adapter.SearchPagingAdapter
 
 class SearchActivity : AppCompatActivity() {
 
     private val vm: SearchViewModel by viewModels()
     private lateinit var binding: ActivitySearchBinding
-    private val adapter = LikePagingAdapter()
+    private val adapter = SearchPagingAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/inu/events/ui/home/SearchActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/home/SearchActivity.kt
@@ -1,5 +1,6 @@
 package org.inu.events.ui.home
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -8,10 +9,13 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import org.inu.events.common.extension.toast
 import org.inu.events.data.model.entity.Event
 import org.inu.events.databinding.ActivitySearchBinding
 import org.inu.events.ui.adapter.SearchPagingAdapter
 import org.inu.events.ui.detail.DetailActivity
+import org.inu.events.ui.login.LoginActivity
+import org.inu.events.ui.util.dialog.LoginDialog
 
 class SearchActivity : AppCompatActivity() {
 
@@ -40,6 +44,11 @@ class SearchActivity : AppCompatActivity() {
         setContentView(binding.root)
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        vm.search()
+    }
 
     private fun initRecyclerView() {
         binding.rvEvent.adapter = adapter
@@ -65,7 +74,17 @@ class SearchActivity : AppCompatActivity() {
         startActivity(DetailActivity.callingIntent(this, event.id, event.wroteByMe))
     }
 
-    private fun onClickLikeIcon(event: Event): Boolean {
-        return false
+    private fun onClickLikeIcon(event: Event) {
+        vm.bookMarkByToggle(event.likedByMe, event.id).run {
+            if (this.not()) showDialog()
+            else vm.search()
+        }
+    }
+
+    private fun showDialog() {
+        LoginDialog().show(
+            context = this,
+            onOk = { this.startActivity(Intent(this, LoginActivity::class.java)) },
+            onCancel = { toast("로그인을 하셔야 북마크가 가능합니다") })
     }
 }

--- a/app/src/main/java/org/inu/events/ui/home/SearchActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/home/SearchActivity.kt
@@ -8,14 +8,23 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import org.inu.events.data.model.entity.Event
 import org.inu.events.databinding.ActivitySearchBinding
 import org.inu.events.ui.adapter.SearchPagingAdapter
+import org.inu.events.ui.detail.DetailActivity
 
 class SearchActivity : AppCompatActivity() {
 
     private val vm: SearchViewModel by viewModels()
     private lateinit var binding: ActivitySearchBinding
-    private val adapter = SearchPagingAdapter()
+    private val adapter = SearchPagingAdapter(
+        onClickEvent = {
+            onClickSearchedEvent(it)
+        },
+        onCLickLikeIcon = {
+            onClickLikeIcon(it)
+        }
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,5 +59,13 @@ class SearchActivity : AppCompatActivity() {
         binding.tvBack.setOnClickListener {
             finish()
         }
+    }
+
+    private fun onClickSearchedEvent(event: Event) {
+        startActivity(DetailActivity.callingIntent(this, event.id, event.wroteByMe))
+    }
+
+    private fun onClickLikeIcon(event: Event): Boolean {
+        return false
     }
 }

--- a/app/src/main/java/org/inu/events/ui/home/SearchViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/home/SearchViewModel.kt
@@ -3,6 +3,7 @@ package org.inu.events.ui.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
@@ -51,7 +52,7 @@ class SearchViewModel : ViewModel(), KoinComponent {
                 categoryId = category.value,
                 eventStatus = eventStatus.value,
                 content = searchText.value
-            ).collectLatest { pagingData ->
+            ).cachedIn(viewModelScope).collectLatest { pagingData ->
                 searchResult.value = pagingData
             }
         }

--- a/app/src/main/java/org/inu/events/ui/home/SearchViewModel.kt
+++ b/app/src/main/java/org/inu/events/ui/home/SearchViewModel.kt
@@ -4,18 +4,22 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import org.inu.events.data.model.dto.LikeParam
 import org.inu.events.data.model.entity.Event
 import org.inu.events.data.repository.EventRepository
+import org.inu.events.data.repository.LikeRepository
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class SearchViewModel : ViewModel(), KoinComponent {
 
     private val eventRepository: EventRepository by inject()
+    private val likeRepository: LikeRepository by inject()
 
     val searchText = MutableStateFlow("")
     private val category = MutableStateFlow(0)
@@ -46,7 +50,7 @@ class SearchViewModel : ViewModel(), KoinComponent {
         }
     }
 
-    private fun search(): Job {
+    fun search(): Job {
         return viewModelScope.launch {
             eventRepository.searchEvents(
                 categoryId = category.value,
@@ -55,6 +59,32 @@ class SearchViewModel : ViewModel(), KoinComponent {
             ).cachedIn(viewModelScope).collectLatest { pagingData ->
                 searchResult.value = pagingData
             }
+        }
+    }
+
+    fun bookMarkByToggle(onOff: Boolean?, eventId: Int): Boolean {
+        return when (onOff) {
+            true -> {
+                unBookmark(eventId)
+                true
+            }
+            false -> {
+                bookmark(eventId)
+                true
+            }
+            null -> false
+        }
+    }
+
+    private fun bookmark(eventId: Int) {
+        viewModelScope.launch(Dispatchers.IO) {
+            likeRepository.postLike(LikeParam(eventId))
+        }
+    }
+
+    private fun unBookmark(eventId: Int) {
+        viewModelScope.launch(Dispatchers.IO) {
+            likeRepository.deleteLike(LikeParam(eventId))
         }
     }
 }

--- a/app/src/main/java/org/inu/events/ui/mypage/store/LikeActivity.kt
+++ b/app/src/main/java/org/inu/events/ui/mypage/store/LikeActivity.kt
@@ -2,7 +2,7 @@ package org.inu.events.ui.mypage.store
 
 import androidx.activity.viewModels
 import org.inu.events.R
-import org.inu.events.ui.adapter.like.LikeAdapter
+import org.inu.events.ui.adapter.LikeAdapter
 import org.inu.events.base.BaseActivity
 import org.inu.events.databinding.ActivityLikeBinding
 

--- a/app/src/main/res/layout/item_search_event.xml
+++ b/app/src/main/res/layout/item_search_event.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+
+        <variable
+            name="item"
+            type="org.inu.events.data.model.entity.Event" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="140dp"
+            android:layout_marginHorizontal="@dimen/horizontal_margin"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="16dp"
+            android:elevation="8dp"
+            app:cardCornerRadius="6dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/card_wrap"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingHorizontal="12dp">
+
+                <ImageView
+                    android:id="@+id/poster"
+                    bindImageRadius4="@{item.imageUuid}"
+                    android:layout_width="85dp"
+                    android:layout_height="120dp"
+                    android:background="@drawable/outline_border_4"
+                    android:padding="1dp"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:text="@{item.title}"
+                    android:textColor="@color/black1"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toStartOf="@id/bookmark_icon"
+                    app:layout_constraintStart_toEndOf="@id/poster"
+                    app:layout_constraintTop_toTopOf="@id/poster"
+                    tools:text="현장체험 (인천십) 실습생 모집 공고 근데 더 길게 써야 한다." />
+
+                <ImageButton
+                    android:id="@+id/bookmark_icon"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:background="@{item.likedByMe ? @drawable/ic_bookmark_filled : @drawable/ic_bookmark_outlined}"
+                    app:layout_constraintBottom_toBottomOf="@id/title"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/title"
+                    tools:src="@drawable/ic_bookmark_filled" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:ellipsize="end"
+                    android:maxLines="3"
+                    android:text="@{item.body}"
+                    android:textColor="@color/black60"
+                    android:textSize="13sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/title"
+                    app:layout_constraintTop_toBottomOf="@id/title"
+                    tools:text="2021년 스타트업 현장체험(인턴십) 실습생 모집합니다. 인천대학교 창업지원단 홈페이지에서 양식을 다운받아 창업지원단 창업지원단 창업지원단 창업지원단 창업지원단 창업지원단 창업지원단 창업지원단" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text='@{"댓글 " + item.comments}'
+                    android:textColor="@color/black20"
+                    android:textSize="13sp"
+                    app:layout_constraintBottom_toBottomOf="@id/poster"
+                    app:layout_constraintStart_toStartOf="@id/title"
+                    tools:text="댓글 12" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## 개요
검색된 행사들이 클릭해도 상세 화면으로 넘어가지 않았다.

## 분석
Clik Event  처리가 되어있지 않았다.

## 해결
상세화면으로 넘어가도록 수정

---

## 개요
북마크가 항상 켜져있었다. 클릭해도 무반응

## 분석
나의 레터의 저장항목 item Ui 를 사용하고 있었다.  
해당 UI 에선 항상 북마크가 On 상태로 고정되고 있었다.

## 해결
새로운 item UI 구현 및 북마크 클릭에 따른 동작처리